### PR TITLE
Switch to having all form processing client-side using JavaScript in the browser

### DIFF
--- a/accuconf_cfp/utils.py
+++ b/accuconf_cfp/utils.py
@@ -4,13 +4,32 @@ A collection of functions used by various route controllers. The route controlle
 are in separate modules hence pulling these functions out into a separate module.
 """
 
+import hashlib
 import re
 
 from flask import redirect, session
 
 from accuconf_cfp import app
 
-from models.user import User
+
+def hash_passphrase(text):
+    return hashlib.sha512(text.encode('utf-8')).hexdigest()
+
+
+def is_acceptable_route():
+    """Check the state of the application and return a pair.
+
+    The first item of the pair is a Boolean stating whether the route is acceptable.
+    The second item of the pair is a rendered template to display if the route is not
+     allowed, and None if it is.
+    """
+    if app.config['MAINTENANCE']:
+        return False, redirect('/')
+    if not app.config['CALL_OPEN']:
+        if app.config['REVIEWING_ALLOWED']:
+            return True, None
+        return False, redirect('/')
+    return True, None
 
 
 def is_logged_in():
@@ -22,20 +41,10 @@ def is_logged_in():
     return 'email' in session and session['email']
 
 
-def is_acceptable_route():
-    """Check the state of the application and return a pair.
-
-    The first item of the pair is a Boolean stating whether the route is acceptable.
-    The second item of the pair is a rendered template to display if the route is not
-     allowed, and None if it is.
-    """
-    if app.config['MAINTENANCE']:
-        return (False, redirect('/'))
-    if not app.config['CALL_OPEN']:
-        if app.config['REVIEWING_ALLOWED']:
-            return (True, None)
-        return (False, redirect('/'))
-    return (True, None)
+def is_valid_email(email):
+    """A purported email address in in valid format."""
+    email_pattern = re.compile("^([a-zA-Z0-9_.+-])+@(([a-zA-Z0-9-_])+\.)+([a-zA-Z0-9])+$")
+    return email_pattern.search(email)
 
 
 #  This code has to work on Python 3.4, so cannot use the lovely Python 3.5 and later stuff.
@@ -47,41 +56,26 @@ def md(a, b):
     return rv
 
 
-def is_valid_new_email(email):
-    """Proposed new email is valide format and not already in use."""
-    email_pattern = re.compile("^([a-zA-Z0-9_.+-])+@(([a-zA-Z0-9-_])+\.)+([a-zA-Z0-9])+$")
-    if email_pattern.search(email):
-        return not User.query.filter_by(email=email).first()
-    else:
-        return False
-
-
 def validate_proposal_data(proposal_data):
     """Proposal data is not invalid."""
-    mandatory_keys = ["title", "abstract", "session_type", "presenters"]
+    mandatory_keys = ['title', 'abstract', 'session_type', 'presenters']
     for key in mandatory_keys:
         if key not in proposal_data:
-            return False, "{} information is not present in proposal".format(key)
-
+            return False, '{} information is not present in proposal'.format(key)
         if proposal_data[key] is None:
-            return False, "{} information should not be empty".format(key)
-    if type(proposal_data["presenters"]) != list:
-        return False, "presenters data is malformed"
-
-    if len(proposal_data["presenters"]) < 1:
-        return False, "At least one presenter needed"
-
-    if len(proposal_data.get("title")) < 5:
-        return False, "Title is too short"
-
-    if len(proposal_data.get("abstract")) < 50:
-        return False, "Proposal too short"
-
-    (result, message) = validate_presenters(proposal_data["presenters"])
+            return False, '{} information should not be empty'.format(key)
+    if type(proposal_data['presenters']) != list:
+        return False, 'presenters data is malformed'
+    if len(proposal_data['presenters']) < 1:
+        return False, 'At least one presenter needed'
+    if len(proposal_data.get('title')) < 5:
+        return False, 'Title is too short'
+    if len(proposal_data.get('abstract')) < 50:
+        return False, 'Proposal too short'
+    (result, message) = validate_presenters(proposal_data['presenters'])
     if not result:
         return result, message
-
-    return True, "validated"
+    return True, 'validated'
 
 
 def validate_presenters(presenters):

--- a/accuconf_cfp/views/login.py
+++ b/accuconf_cfp/views/login.py
@@ -1,13 +1,26 @@
-import hashlib
-
 from flask import redirect, render_template, request, session
 
 from accuconf_cfp import app, year
-from accuconf_cfp.utils import is_acceptable_route
+from accuconf_cfp.utils import hash_passphrase, is_acceptable_route, is_valid_email
 
 from accuconf_cfp.utils import md
 
 from models.user import User
+
+
+def validate_login_data(login_data):
+    if not login_data:
+        return False, 'No JSON data returned.'
+    mandatory_keys = ['email', 'passphrase']
+    missing_keys = [key for key in mandatory_keys if key not in login_data]
+    if missing_keys:
+        return False, 'Missing keys in registration data: {}'.format(missing_keys)
+    if not is_valid_email(login_data['email']):
+        return False, 'The email address is invalid.'
+    user = User.query.filter_by(email=login_data['email']).first()
+    if not user or user.passphrase != login_data['passphrase']:
+        return False, 'User/passphrase not recognised.'
+    return user, None
 
 
 @app.route('/login', methods=['GET', 'POST'])
@@ -22,18 +35,13 @@ def login():
         'year': year,
     }
     if request.method == 'POST':
-        email = request.form['email']
-        passphrase = request.form['passphrase']
-        user = User.query.filter_by(email=email).first()
+        login_data = request.json
+        user, message = validate_login_data(login_data)
         if not user:
-            return render_template('failure.html', page=md(page, {'data': 'Login was not successful.'}))
-        passphrase_hash = hashlib.sha256(passphrase.encode("utf-8")).hexdigest()
-        if user.passphrase == passphrase_hash:
-            session['email'] = user.email
-            #  TODO  Change something so as to see the login state. Menu changes of course.
-            return redirect('/')
-        else:
-            return render_template('failure.html', page=md(page, {'data': 'Login was not successful.'}))
+            return render_template('failure.html', page=md(page, {'data': message}))
+        session['email'] = user.email
+        #  TODO  Change something so as to see the login state. Menu changes of course.
+        return render_template('success.html', page=md(page, {'data': 'Login successful.'}))
     else:
         return render_template('login.html', page=page)
 

--- a/test_utils/fixtures.py
+++ b/test_utils/fixtures.py
@@ -27,8 +27,12 @@ def database():
 @pytest.fixture()
 def client():
     """A Werkzeug client in testing mode with a newly created database.
+
+    Whatever the location of the database for the current configuration,
+    override it for the tests.
     """
     app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
     with app.app_context():
         db.drop_all()
         db.create_all()

--- a/tests_cfp/test_proposal_models.py
+++ b/tests_cfp/test_proposal_models.py
@@ -1,6 +1,6 @@
 """
 Test putting instances of various proposal related types into the database
-and retrieving values and creating new instances of equal value..
+and retrieving values and creating new instances of equal value.
 """
 
 # Apparently unused but loading has crucial side effects
@@ -14,9 +14,11 @@ from models.proposal_types import SessionType, ProposalState, SessionCategory, S
 # PyCharm believes it isn't a used symbol, but it is.
 from test_utils.fixtures import database
 
+from accuconf_cfp.utils import hash_passphrase
+
 user_data = {
     'email': 'abc@b.c',
-    'passphrase': 'passphrase',
+    'passphrase': hash_passphrase('This is an interesting passphrase.'),
     'name': 'User Name',
     'country': 'IND',
     'state': 'KARNATAKA',
@@ -44,6 +46,12 @@ proposal_data = {
 
 
 def test_putting_proposal_in_database(database):
+    """Put a proposal item into the database.
+
+    A proposal has to be submitted by a user so tehre must be a user.
+    Proposals must also have at least one presenter, by default the user is
+    the lead presenter.
+    """
     user = User(**user_data)
     proposal = Proposal(user, **proposal_data)
     presenter = Presenter(**presenter_data)
@@ -74,6 +82,12 @@ def test_putting_proposal_in_database(database):
 
 
 def test_adding_review_and_comment_to_proposal_in_database(database):
+    """A reviewed proposal has a score and possible a comment added.
+
+    Put a proposal with user and presenter into the database. Although this is not
+    allowed in the application have the user score and comment on their proposal
+    to show that this all works in the database.
+    """
     user = User(**user_data)
     proposal = Proposal(user, **proposal_data)
     presenter = Presenter(**presenter_data)

--- a/tests_cfp/test_registration.py
+++ b/tests_cfp/test_registration.py
@@ -2,6 +2,8 @@
 Tests for various uses of the /register route.
 """
 
+import json
+
 import pytest
 
 # Apparently unused but loading has crucial side effects.
@@ -9,79 +11,88 @@ import configure
 
 from accuconf import app
 
+from models.user import User
+
+from accuconf_cfp.utils import hash_passphrase
+
 from test_utils.constants import login_menu_item, register_menu_item
 # PyCharm fails to spot this is used as a fixture.
 from test_utils.fixtures import client
 from test_utils.functions import get_and_check_content, post_and_check_content
+
+# TODO For some reason we have to import the class Score, why?
+from models.score import Score
 
 
 @pytest.fixture
 def registrant():
     return {
         'email': 'a@b.c',
-        'passphrase': 'Passphrase1',
-        'cpassphrase': 'Passphrase1',
+        'passphrase': hash_passphrase('Passphrase for someone'),
         'name': 'User Name',
         'phone': '+011234567890',
         'country': 'India',
         'state': 'TamilNadu',
-        'postalcode': '123456',
-        'towncity': 'Chennai',
-        'streetaddress': 'Chepauk',
-        'captcha': '1',
-        'question': '12',
+        'postal_code': '123456',
+        'town_city': 'Chennai',
+        'street_address': 'Chepauk',
     }
 
 
 def test_registration_page_has_some_countries(client, monkeypatch):
     monkeypatch.setitem(app.config, 'CALL_OPEN', True)
     monkeypatch.setitem(app.config, 'MAINTENANCE', False)
-    get_and_check_content(client, '/register', includes=('Register', 'United Kingdom'), excludes=(register_menu_item, 'GBR'))
+    get_and_check_content(client, '/register',
+                          includes=('Register', 'United Kingdom'),
+                          excludes=(register_menu_item, 'GBR'))
+
+
+def test_attempted_form_submit_not_json_fails(client, registrant, monkeypatch):
+    monkeypatch.setitem(app.config, 'CALL_OPEN', True)
+    monkeypatch.setitem(app.config, 'MAINTENANCE', False)
+    user = User.query.filter_by(email=registrant['email']).all()
+    assert len(user) == 0
+    post_and_check_content(client, '/register', registrant,
+                           includes=('Registration Failure', 'No JSON data returned', login_menu_item),
+                           excludes=(register_menu_item,))
+    user = User.query.filter_by(email=registrant['email']).all()
+    assert len(user) == 0
 
 
 def test_successful_user_registration(client, registrant, monkeypatch):
     monkeypatch.setitem(app.config, 'CALL_OPEN', True)
     monkeypatch.setitem(app.config, 'MAINTENANCE', False)
-    post_and_check_content(client, '/register', registrant, includes=('You have successfully registered', 'Please login', login_menu_item), excludes=(register_menu_item,))
+    user = User.query.filter_by(email=registrant['email']).all()
+    assert len(user) == 0
+    post_and_check_content(client, '/register', json.dumps(registrant), 'application/json',
+                           includes=('You have successfully registered', 'Please login', login_menu_item),
+                           excludes=(register_menu_item,))
+    user = User.query.filter_by(email=registrant['email']).all()
+    assert len(user) == 1
+    assert user[0].email == registrant['email']
+    assert user[0].passphrase == registrant['passphrase']
 
 
 def test_attempted_duplicate_user_registration_fails(client, registrant, monkeypatch):
     test_successful_user_registration(client, registrant, monkeypatch)
-    post_and_check_content(client, '/register', registrant, includes=('The email address was either invalid or already in use.', login_menu_item), excludes=(register_menu_item,))
+    post_and_check_content(client, '/register', json.dumps(registrant), 'application/json',
+                           includes=('The email address is already in use.', login_menu_item),
+                           excludes=(register_menu_item,))
 
 
-def test_passphrase_and_cpassphrase_present_but_differ(client, registrant, monkeypatch):
-    monkeypatch.setitem(app.config, 'CALL_OPEN', True)
-    monkeypatch.setitem(app.config, 'MAINTENANCE', False)
-    registrant['passphrase'] = 'the lazy dog'
-    registrant['cpassphrase'] = 'brown fox'
-    post_and_check_content(client, '/register', registrant, includes=('Passphrase and confirmation passphrase dffer.', login_menu_item), excludes=(register_menu_item,))
-
-
-def test_no_passphrase_or_cpassphrase(client, registrant, monkeypatch):
+def test_no_passphrase(client, registrant, monkeypatch):
     monkeypatch.setitem(app.config, 'CALL_OPEN', True)
     monkeypatch.setitem(app.config, 'MAINTENANCE', False)
     registrant['passphrase'] = ''
-    registrant['cpassphrase'] = ''
-    post_and_check_content(client, '/register', registrant, includes=('Neither passphrase nor confirmation passphrase entered.', login_menu_item), excludes=(register_menu_item,))
-
-
-def test_passphrase_but_no_cpassphrase(client, registrant, monkeypatch):
-    monkeypatch.setitem(app.config, 'CALL_OPEN', True)
-    monkeypatch.setitem(app.config, 'MAINTENANCE', False)
-    registrant['cpassphrase'] = ''
-    post_and_check_content(client, '/register', registrant, includes=('Passphrase given but no confirmation passphrase', login_menu_item), excludes=(register_menu_item,))
-
-
-def test_no_passphrase_but_cpassphrase(client, registrant, monkeypatch):
-    monkeypatch.setitem(app.config, 'CALL_OPEN', True)
-    monkeypatch.setitem(app.config, 'MAINTENANCE', False)
-    registrant['passphrase'] = ''
-    post_and_check_content(client, '/register', registrant, includes=('No passphrase given but even though confirmation passphrase given.', login_menu_item), excludes=(register_menu_item,))
+    post_and_check_content(client, '/register', json.dumps(registrant), 'application/json',
+                           includes=('No passphrase for new registration.', login_menu_item),
+                           excludes=(register_menu_item,))
 
 
 def test_invalid_email(client, registrant, monkeypatch):
     monkeypatch.setitem(app.config, 'CALL_OPEN', True)
     monkeypatch.setitem(app.config, 'MAINTENANCE', False)
     registrant['email'] = 'thing.flob.adob'
-    post_and_check_content(client, '/register', registrant, includes=('The email address was either invalid or already in use', login_menu_item), excludes=(register_menu_item,))
+    post_and_check_content(client, '/register', json.dumps(registrant), 'application/json',
+                           includes=('The email address is invalid.', login_menu_item),
+                           excludes=(register_menu_item,))

--- a/tests_cfp/test_user_models.py
+++ b/tests_cfp/test_user_models.py
@@ -12,17 +12,21 @@ from test_utils.fixtures import database
 
 from models.user import User
 
+from accuconf_cfp.utils import hash_passphrase
+
 # Apparently this class has to be loaded for things to work at runtime.
 # This is sort of understandable, but only if Comment and Proposal also
 # have to be imported. Yet they do not, so confusion exists.
 from models.score import Score
+
+passphrase = hash_passphrase('Some pass phrase or other.')
 
 
 @pytest.mark.parametrize('user_data', (
     # A user with all fields set.
     {
         'email': 'a@b.c',
-        'passphrase': 'passphrase',
+        'passphrase': passphrase,
         'name': 'User Name',
         'country': 'Some Country',
         'state': 'Some State',
@@ -35,17 +39,18 @@ from models.score import Score
     # for the missing fields.
     {
         'email': 'a@b.c',
-        'passphrase': 'passphrase',
+        'passphrase': passphrase,
         'name': 'User Name',
         'country': 'Some Country',
         'postal_code': 'Postcode',
         'town_city': 'Town or City',
         'street_address': 'Street Address',
     }))
-def test_user_in_database(user_data, database):
+def test_putting_user_data_into_database(user_data, database):
     """Ensure that we can put a user with no proposals or other data into the database.
 
-    Having users with proposals, scores and comments comes later.
+    Having users with proposals, scores and comments comes later,
+    this is simulating registration activity in the database.
     """
     u = User(**user_data)
     database.session.add(u)


### PR DESCRIPTION
All the tests now assume JSON input of validated data. handling checking passphrase and cpassphrase and hashing to SHA512 is now assumed to be done in the browser. Some checks are repeated server-side just in case. The one check that has to happen server-side is duplication of email address.

This still uses failure HTML rendering, this must now be switched to shipping back error messages as JSON to the sending form page . 