### PR TITLE
Changes to functional tests

### DIFF
--- a/tests_cfp__selenium/constants.py
+++ b/tests_cfp__selenium/constants.py
@@ -1,0 +1,1 @@
+driver_wait_time = 2

--- a/tests_cfp__selenium/fixtures.py
+++ b/tests_cfp__selenium/fixtures.py
@@ -29,7 +29,7 @@ def server():
     assert process.returncode == -15, 'Server terminated return code {}.'.format(process.returncode)
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def driver():
     # It seems that PhantomJS cannot handle the button clicking.
     # wd = webdriver.PhantomJS()
@@ -41,3 +41,19 @@ def driver():
     wd = webdriver.Chrome(chrome_options=options)
     yield wd
     wd.quit()
+
+
+@pytest.fixture
+def registrant():
+    return {
+        'email': 'a@b.c',
+        'passphrase': 'Passphrase1',
+        'cpassphrase': 'Passphrase1',
+        'name': 'User Name',
+        'phone': '+011234567890',
+        'country': 'India',
+        'state': 'TamilNadu',
+        'postal_code': '123456',
+        'town_city': 'Chennai',
+        'street_address': 'Chepauk',
+    }

--- a/tests_cfp__selenium/test_s_logged_in_page_accessibility.py
+++ b/tests_cfp__selenium/test_s_logged_in_page_accessibility.py
@@ -6,36 +6,19 @@ from selenium.webdriver.support import expected_conditions as ecs
 
 from configuration import base_url
 from functions import check_menu_items
+from constants import driver_wait_time
 
 # NB PyCharm can't tell these are used as fixtures, but they are.
 # NB server is an session scope autouse fixture that no test needs direct access to.
-from fixtures import driver, server
+from fixtures import driver, server, registrant
 
-# NB The server is in "call open" state.
-
-
-@pytest.fixture
-def registrant():
-    return {
-        'email': 'a@b.c',
-        'passphrase': 'Passphrase1',
-        'cpassphrase': 'Passphrase1',
-        'name': 'User Name',
-        'phone': '+011234567890',
-        'country': 'India',
-        'state': 'TamilNadu',
-        'postal_code': '123456',
-        'town_city': 'Chennai',
-        'street_address': 'Chepauk',
-    }
-
-user_is_registered = False
+user_is_logged_in = False
 
 
 def register_and_login_user(driver, registrant):
-    if not user_is_registered:
+    if not user_is_logged_in:
         driver.get(base_url + 'register')
-        wait = WebDriverWait(driver, 4)
+        wait = WebDriverWait(driver, driver_wait_time)
         wait.until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Register'))
         for key, value in registrant.items():
             driver.find_element_by_id(key).send_keys(value)
@@ -47,93 +30,85 @@ def register_and_login_user(driver, registrant):
         button.click()
         wait.until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Registration Successful'))
         assert 'You have successfully registered for submitting proposals for the ACCU' in driver.find_element_by_id('content').text
-        global user_is_registered
-        user_is_registered = True
-    driver.get(base_url + 'login')
-    wait = WebDriverWait(driver, 4)
-    wait.until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Login'))
-    driver.find_element_by_id('email').send_keys(registrant['email'])
-    driver.find_element_by_id('passphrase').send_keys(registrant['passphrase'])
-    button = wait.until(ecs.element_to_be_clickable((By.ID, 'login')))
-    button.click()
-    wait.until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), 'Login Successful'))
+        global user_is_logged_in
+        user_is_logged_in = True
+        driver.get(base_url + 'login')
+        wait = WebDriverWait(driver, driver_wait_time)
+        wait.until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Login'))
+        driver.find_element_by_id('email').send_keys(registrant['email'])
+        driver.find_element_by_id('passphrase').send_keys(registrant['passphrase'])
+        button = wait.until(ecs.element_to_be_clickable((By.ID, 'login')))
+        button.click()
+        wait.until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), 'Login Successful'))
 
 
 def test_logged_in_user_can_get_root_page(driver, registrant):
     register_and_login_user(driver, registrant)
     driver.get(base_url)
-    # assert 'Call for Proposals' in driver.find_element_by_tag_name('title').text
-    assert ' – Call for Proposals' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Call for Proposals'))
     check_menu_items(driver, ())
 
 
 def test_logged_in_user_cannot_get_register_page(driver, registrant):
     register_and_login_user(driver, registrant)
     driver.get(base_url + 'register')
-    # assert 'Call for Proposals' in driver.find_element_by_tag_name('title').text
-    assert ' – Call for Proposals' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Call for Proposals'))
     check_menu_items(driver, ())
 
 
 def test_logged_in_user_cannot_access_register_success_even_after_logged_in(driver, registrant):
     register_and_login_user(driver, registrant)
     driver.get(base_url + 'register_success')
-    # assert 'Call for Proposals' in driver.find_element_by_tag_name('title').text
-    assert ' – Call for Proposals' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Call for Proposals'))
     check_menu_items(driver, ())
 
 
 def test_logged_in_user_can_get_registration_update_page(driver, registrant):
     register_and_login_user(driver, registrant)
     driver.get(base_url + 'registration_update')
-    # assert 'Registration Details Updating' in driver.find_element_by_tag_name('title').text
-    assert ' – Registration Details Updating' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Registration Details Updating'))
     check_menu_items(driver, ())
 
 
 def test_logged_in_user_cannot_access_registration_update_success_page_logged_in(driver, registrant):
     register_and_login_user(driver, registrant)
     driver.get(base_url + 'registration_update_success')
-    # assert 'Call for Proposals' in driver.find_element_by_tag_name('title').text
-    assert ' – Call for Proposals' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Call for Proposals'))
     check_menu_items(driver, ())
 
 
 def test_logged_in_user_cannot_get_login_page(driver, registrant):
     register_and_login_user(driver, registrant)
     driver.get(base_url + 'login')
-    # assert 'Call for Proposals' in driver.find_element_by_tag_name('title').text
-    assert ' – Call for Proposals' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Call for Proposals'))
     check_menu_items(driver, ())
 
 
 def test_logged_in_user_cannot_access_login_success_page(driver, registrant):
     register_and_login_user(driver, registrant)
     driver.get(base_url + 'login_success')
-    # assert 'Call for Proposals' in driver.find_element_by_tag_name('title').text
-    assert ' – Call for Proposals' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Call for Proposals'))
     check_menu_items(driver, ())
-
-
-def test_logged_in_user_can_get_logout_page(driver, registrant):
-    register_and_login_user(driver, registrant)
-    driver.get(base_url + 'logout')
-    # assert 'Call for Proposals' in driver.find_element_by_tag_name('title').text
-    assert ' – Call for Proposals' in driver.find_element_by_class_name('pagetitle').text
-    check_menu_items(driver, ('Register', 'Login'))
 
 
 def test_logged_in_user_can_get_submit_page(driver, registrant):
     register_and_login_user(driver, registrant)
     driver.get(base_url + 'submit')
-    # assert 'Submit a proposal for ACCU' in driver.find_element_by_tag_name('title').text
-    assert ' – Submit a proposal for ACCU' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Submit a proposal for ACCU'))
     check_menu_items(driver, ())
 
 
 def test_logged_in_user_can_get_my_proposals_page(driver, registrant):
     register_and_login_user(driver, registrant)
     driver.get(base_url + 'my_proposals')
-    # assert 'My Proposals' in driver.find_element_by_tag_name('title').text
-    assert ' – My Proposals' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – My Proposals'))
     check_menu_items(driver, ())
+
+
+# This test changes the state of the per module driver and so must be run as the last test in this module.
+# By default pytest runs tests in declaration order so this should not be fragile.
+def test_logged_in_user_can_get_logout_page(driver, registrant):
+    register_and_login_user(driver, registrant)
+    driver.get(base_url + 'logout')
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Call for Proposals'))
+    check_menu_items(driver, ('Register', 'Login'))

--- a/tests_cfp__selenium/test_s_not_logged_in_page_accessibility.py
+++ b/tests_cfp__selenium/test_s_not_logged_in_page_accessibility.py
@@ -1,81 +1,74 @@
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as ecs
+
 from configuration import base_url
 from functions import check_menu_items
+from constants import driver_wait_time
 
 # NB PyCharm can't tell these are used as fixtures, but they are.
 # NB server is an session scope autouse fixture that no test needs direct access to.
 from fixtures import driver, server
 
-# NB The server is in "call open" state.
-
 
 def test_can_get_root_page(driver):
     driver.get(base_url)
-    # assert 'Call for Proposals' in driver.find_element_by_tag_name('title').text
-    assert ' – Call for Proposals' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Call for Proposals'))
     check_menu_items(driver, ('Register', 'Login'))
 
 
 def test_can_get_register_page(driver):
     driver.get(base_url + 'register')
-    # assert 'Registration' in driver.find_element_by_tag_name('title').text
-    assert ' – Register' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Register'))
     assert 'Register here for submitting proposals to the ACCU' in driver.find_element_by_class_name('first').text
     check_menu_items(driver, ('Login',))
 
 
 def test_cannot_access_register_success_page_without_registering(driver):
     driver.get(base_url + 'register_success')
-    # assert 'Call for Proposals' in driver.find_element_by_tag_name('title').text
-    assert ' – Call for Proposals' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Call for Proposals'))
     check_menu_items(driver, ('Register', 'Login'))
 
 
 def test_cannot_get_registration_update_page_not_logged_in(driver):
     driver.get(base_url + 'registration_update')
-    # assert 'Call for Proposals' in driver.find_element_by_tag_name('title').text
-    assert ' – Call for Proposals' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Call for Proposals'))
     check_menu_items(driver, ('Register', 'Login'))
 
 
 def test_cannot_access_registration_update_success_page_not_logged_in(driver):
     driver.get(base_url + 'registration_update_success')
-    # assert 'Call for Proposals' in driver.find_element_by_tag_name('title').text
-    assert ' – Call for Proposals' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Call for Proposals'))
     check_menu_items(driver, ('Register', 'Login'))
 
 
 def test_can_get_login_page(driver):
     driver.get(base_url + 'login')
-    # assert 'Login' in driver.find_element_by_tag_name('title').text
-    assert ' – Login' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Login'))
     check_menu_items(driver, ('Register',))
 
 
 def test_cannot_access_login_success_page_if_not_logged_in(driver):
     driver.get(base_url + 'login_success')
-    # assert 'Call for Proposals' in driver.find_element_by_tag_name('title').text
-    assert ' – Call for Proposals' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Call for Proposals'))
     check_menu_items(driver, ('Register', 'Login'))
 
 
 def test_can_get_logout_page(driver):
     driver.get(base_url + 'logout')
-    # assert 'Call for Proposals' in driver.find_element_by_tag_name('title').text
-    assert ' – Call for Proposals' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Call for Proposals'))
     check_menu_items(driver, ('Register', 'Login'))
 
 
 def test_cannot_get_submit_page_if_not_logged_in(driver):
     driver.get(base_url + 'submit')
-    # assert 'Submit' in driver.find_element_by_tag_name('title').text
-    assert ' – Submit Not Possible' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Submit Not Possible'))
     assert 'You must be registered and logged in to submit a proposal.' in driver.find_element_by_class_name('first').text
     check_menu_items(driver, ('Register', 'Login'))
 
 
 def test_cannot_get_my_proposals_page_unless_logged_in(driver):
     driver.get(base_url + 'my_proposals')
-    # assert 'My Proposals' in driver.find_element_by_tag_name('title').text
-    assert ' – My Proposals Failure' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – My Proposals Failure'))
     assert 'You must be registered and logged in to discover your current proposals' in driver.find_element_by_class_name('first').text
     check_menu_items(driver, ('Register', 'Login'))

--- a/tests_cfp__selenium/test_s_registered_but_not_logged_in_page_accessibility.py
+++ b/tests_cfp__selenium/test_s_registered_but_not_logged_in_page_accessibility.py
@@ -6,28 +6,11 @@ from selenium.webdriver.support import expected_conditions as ecs
 
 from configuration import base_url
 from functions import check_menu_items
+from constants import driver_wait_time
 
 # NB PyCharm can't tell these are used as fixtures, but they are.
 # NB server is an session scope autouse fixture that no test needs direct access to.
-from fixtures import driver, server
-
-# NB The server is in "call open" state.
-
-
-@pytest.fixture
-def registrant():
-    return {
-        'email': 'a@b.c',
-        'passphrase': 'Passphrase1',
-        'cpassphrase': 'Passphrase1',
-        'name': 'User Name',
-        'phone': '+011234567890',
-        'country': 'India',
-        'state': 'TamilNadu',
-        'postal_code': '123456',
-        'town_city': 'Chennai',
-        'street_address': 'Chepauk',
-    }
+from fixtures import driver, server, registrant
 
 user_is_registered = False
 
@@ -35,7 +18,7 @@ user_is_registered = False
 def register_user(driver, registrant):
     if not user_is_registered:
         driver.get(base_url + 'register')
-        wait = WebDriverWait(driver, 4)
+        wait = WebDriverWait(driver, driver_wait_time)
         wait.until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Register'))
         for key, value in registrant.items():
             driver.find_element_by_id(key).send_keys(value)
@@ -54,16 +37,14 @@ def register_user(driver, registrant):
 def test_registered_user_can_get_root_page(driver, registrant):
     register_user(driver, registrant)
     driver.get(base_url)
-    # assert 'Call for Proposals' in driver.find_element_by_tag_name('title').text
-    assert ' – Call for Proposals' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Call for Proposals'))
     check_menu_items(driver, ('Register', 'Login'))
 
 
 def test_registered_user_can_get_register_page(driver, registrant):
     register_user(driver, registrant)
     driver.get(base_url + 'register')
-    # assert 'Registration' in driver.find_element_by_tag_name('title').text
-    assert ' – Register' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Register'))
     assert 'Register here for submitting proposals to the ACCU' in driver.find_element_by_class_name('first').text
     check_menu_items(driver, ('Login',))
 
@@ -71,56 +52,49 @@ def test_registered_user_can_get_register_page(driver, registrant):
 def test_registered_user_cannot_access_register_success_even_after_registering(driver, registrant):
     register_user(driver, registrant)
     driver.get(base_url + 'register_success')
-    # assert 'Call for Proposals' in driver.find_element_by_tag_name('title').text
-    assert ' – Call for Proposals' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Call for Proposals'))
     check_menu_items(driver, ('Register', 'Login'))
 
 
 def test_registered_user_cannot_get_registration_update_page_not_logged_in(driver, registrant):
     register_user(driver, registrant)
     driver.get(base_url + 'registration_update')
-    # assert 'Call for Proposals' in driver.find_element_by_tag_name('title').text
-    assert ' – Call for Proposals' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Call for Proposals'))
     check_menu_items(driver, ('Register', 'Login'))
 
 
 def test_registered_user_cannot_access_registration_update_success_page_not_logged_in(driver, registrant):
     register_user(driver, registrant)
     driver.get(base_url + 'registration_update_success')
-    # assert 'Call for Proposals' in driver.find_element_by_tag_name('title').text
-    assert ' – Call for Proposals' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Call for Proposals'))
     check_menu_items(driver, ('Register', 'Login'))
 
 
 def test_registered_user_can_get_login_page(driver, registrant):
     register_user(driver, registrant)
     driver.get(base_url + 'login')
-    # assert 'Login' in driver.find_element_by_tag_name('title').text
-    assert ' – Login' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Login'))
     check_menu_items(driver, ('Register',))
 
 
 def test_registered_user_cannot_access_login_success_page_if_not_logged_in(driver, registrant):
     register_user(driver, registrant)
     driver.get(base_url + 'login_success')
-    # assert 'Call for Proposals' in driver.find_element_by_tag_name('title').text
-    assert ' – Call for Proposals' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Call for Proposals'))
     check_menu_items(driver, ('Register', 'Login'))
 
 
 def test_registered_user_can_get_logout_page(driver, registrant):
     register_user(driver, registrant)
     driver.get(base_url + 'logout')
-    # assert 'Call for Proposals' in driver.find_element_by_tag_name('title').text
-    assert ' – Call for Proposals' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Call for Proposals'))
     check_menu_items(driver, ('Register', 'Login'))
 
 
 def test_registered_user_cannot_get_submit_page_if_not_logged_in(driver, registrant):
     register_user(driver, registrant)
     driver.get(base_url + 'submit')
-    # assert 'Submit' in driver.find_element_by_tag_name('title').text
-    assert ' – Submit Not Possible' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Submit Not Possible'))
     assert 'You must be registered and logged in to submit a proposal.' in driver.find_element_by_class_name('first').text
     check_menu_items(driver, ('Register', 'Login'))
 
@@ -128,7 +102,6 @@ def test_registered_user_cannot_get_submit_page_if_not_logged_in(driver, registr
 def test_registered_user_cannot_get_my_proposals_page_unless_logged_in(driver, registrant):
     register_user(driver, registrant)
     driver.get(base_url + 'my_proposals')
-    # assert 'My Proposals' in driver.find_element_by_tag_name('title').text
-    assert ' – My Proposals Failure' in driver.find_element_by_class_name('pagetitle').text
+    WebDriverWait(driver, driver_wait_time).until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – My Proposals Failure'))
     assert 'You must be registered and logged in to discover your current proposals' in driver.find_element_by_class_name('first').text
     check_menu_items(driver, ('Register', 'Login'))

--- a/tests_cfp__selenium/test_s_registered_user_can_login_submit_and_amend_proposals.py
+++ b/tests_cfp__selenium/test_s_registered_user_can_login_submit_and_amend_proposals.py
@@ -5,28 +5,11 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as ecs
 
 from configuration import base_url
+from constants import driver_wait_time
 
 # NB PyCharm can't tell these are used as fixtures, but they are.
 # NB server is an session scope autouse fixture that no test needs direct access to.
-from fixtures import driver, server
-
-# NB The server is in "call open" state.
-
-
-@pytest.fixture
-def registrant():
-    return {
-        'email': 'a@b.c',
-        'passphrase': 'Passphrase1',
-        'cpassphrase': 'Passphrase1',
-        'name': 'User Name',
-        'phone': '+011234567890',
-        'country': 'India',
-        'state': 'TamilNadu',
-        'postal_code': '123456',
-        'town_city': 'Chennai',
-        'street_address': 'Chepauk',
-    }
+from fixtures import driver, server, registrant
 
 user_is_registered = False
 
@@ -34,7 +17,7 @@ user_is_registered = False
 def register_user(driver, registrant):
     if not user_is_registered:
         driver.get(base_url + 'register')
-        wait = WebDriverWait(driver, 4)
+        wait = WebDriverWait(driver, driver_wait_time)
         wait.until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Register'))
         for key, value in registrant.items():
             driver.find_element_by_id(key).send_keys(value)
@@ -53,7 +36,7 @@ def register_user(driver, registrant):
 def test_user_can_successfully_login(driver, registrant):
     register_user(driver, registrant)
     driver.get(base_url + 'login')
-    wait = WebDriverWait(driver, 4)
+    wait = WebDriverWait(driver, driver_wait_time)
     wait.until(ecs.text_to_be_present_in_element((By.CLASS_NAME, 'pagetitle'), ' – Login'))
     driver.find_element_by_id('email').send_keys(registrant['email'])
     driver.find_element_by_id('passphrase').send_keys(registrant['passphrase'])


### PR DESCRIPTION
Make tests less fragile by using a wait after each URL get.

Make tests faster by using a single driver per module.